### PR TITLE
Renamed get_query_set to get_queryset

### DIFF
--- a/organizations/managers.py
+++ b/organizations/managers.py
@@ -1,3 +1,4 @@
+import django
 from django.db import models
 
 
@@ -16,3 +17,6 @@ class ActiveOrgManager(OrgManager):
     def get_queryset(self):
         return super(ActiveOrgManager,
                 self).get_queryset().filter(is_active=True)
+
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset


### PR DESCRIPTION
get_query_set in deprecated in Django 1.8
